### PR TITLE
Fixed collection duplication

### DIFF
--- a/librariansync/cc_update.py
+++ b/librariansync/cc_update.py
@@ -55,7 +55,8 @@ class CCUpdate(object):
                         }
                     ],
                 "isVisibleInHome": 1,
-                "isArchived": 0,
+                "isArchived": 1,
+                "mimeType": "application/x-kindle-collection",
                 "collections": None
             }
         }


### PR DESCRIPTION
With this change collections are not duplicated anymore in some library views.

Tested on PW2 (5.6.1.0.2). It don't break cloud collections in any way.